### PR TITLE
Add `notify-on-failure` command

### DIFF
--- a/src/commands/notify-on-failure.yml
+++ b/src/commands/notify-on-failure.yml
@@ -1,0 +1,77 @@
+description: |
+  Send a notification with Pushover on failure
+
+# NOTE: from the Message API (https://pushover.net/api), I'm only exposing
+# the interface I need at the moment, which means:
+#
+# - title is required
+# - many options aren't here
+#
+# PRs welcome
+parameters:
+  api-key:
+    description: Pushover API Key
+    type: env_var_name
+    default: PUSHOVER_API_KEY
+  user-key:
+    description: Pushover User Key
+    type: env_var_name
+    default: PUSHOVER_USER_KEY
+  title:
+    description: Notification title
+    type: string
+    default: "Failed ${CIRCLE_PROJECT_REPONAME}'s job (${CIRCLE_JOB})"
+  message:
+    description: Notification message
+    type: string
+    default: "Failed ${CIRCLE_USERNAME:=unknown}'s build (#${CIRCLE_BUILD_NUM}) in ${CIRCLE_PROJECT_USERNAME}/${CIRCLE_PROJECT_REPONAME} (${CIRCLE_BRANCH})"
+  priority:
+    description: "Notification priority (low-to-high: -2 to 1)"
+    type: integer
+    default: 1
+  only_for_branches:
+    description: If set, a space-separated list of branches for which to send notifications.
+    type: string
+    default: master
+
+steps:
+  - run:
+      when: on_success
+      name: Pushover - Setting Success Condition
+      command: |
+        echo 'export PUSHOVER_BUILD_STATUS="success"' > /tmp/PUSHOVER_JOB_STATUS
+
+  - run:
+      when: on_fail
+      name: Pushover - Setting Failure Condition
+      command: |
+        echo 'export PUSHOVER_BUILD_STATUS="fail"' > /tmp/PUSHOVER_JOB_STATUS
+
+  - run:
+      when: always
+      name: Notify via Pushover on failure
+      command: |
+        . /tmp/PUSHOVER_JOB_STATUS
+        current_branch_in_filter=false
+
+        for i in << parameters.only_for_branches>>; do
+          if [ "$i" = "$CIRCLE_BRANCH" ]; then
+            current_branch_in_filter=true
+          fi
+        done
+
+        if [ "x" = "x<< parameters.only_for_branches>>" -o "$current_branch_in_filter" = "true" ]; then
+          # If successful
+          if [ "$PUSHOVER_BUILD_STATUS" = "success" ]; then
+            echo "The job completed successfully"
+          # If Failed
+          else
+            curl -s \
+              --form-string "token=${<<parameters.api-key>>}" \
+              --form-string "user=${<<parameters.user-key>>}" \
+              --form-string "title=<<parameters.title>>" \
+              --form-string "message=<<parameters.message>>" \
+              --form-string "priority=<<parameters.priority>>" \
+              https://api.pushover.net/1/messages.json
+          fi
+        fi

--- a/src/commands/notify.yml
+++ b/src/commands/notify.yml
@@ -24,7 +24,7 @@ parameters:
     description: Notification message
     type: string
   priority:
-    description: 'Notification priority (low-to-high: -2 to 1)'
+    description: "Notification priority (low-to-high: -2 to 1)"
     type: integer
     default: 0
   fail_only:

--- a/src/commands/notify.yml
+++ b/src/commands/notify.yml
@@ -27,15 +27,75 @@ parameters:
     description: 'Notification priority (low-to-high: -2 to 1)'
     type: integer
     default: 0
+  fail_only:
+    description: If `true`, notifications successful jobs will not be sent
+    type: boolean
+    default: false
+  only_for_branches:
+    description: If set, a comma-separated list of branches for which to send notifications. No spaces.
+    type: string
+    default: ""
 
 steps:
   - run:
-      name: Notify via Pushover
+      name: Pushover - Setting Failure Condition
       command: |
-        curl -s \
-          --form-string "token=${<<parameters.api-key>>}" \
-          --form-string "user=${<<parameters.user-key>>}" \
-          --form-string "title=<<parameters.title>>" \
-          --form-string "message=<<parameters.message>>" \
-          --form-string "priority=<<parameters.priority>>" \
-          https://api.pushover.net/1/messages.json
+        echo 'export PUSHOVER_BUILD_STATUS="fail"' >> $BASH_ENV
+      when: on_fail
+
+  - run:
+      name: Pushover - Setting Success Condition
+      command: |
+        echo 'export PUSHOVER_BUILD_STATUS="success"' >> $BASH_ENV
+      when: on_success
+
+  - run:
+      name: Provide error if non-bash shell
+      command: |
+        if [ ! -x /bin/bash ]; then
+          echo Bash not installed.
+          exit 1
+        fi
+
+  - run:
+      name: Notify via Pushover
+      shell: /bin/bash
+      when: always
+      command: |
+        current_branch_in_filter=false
+
+        IFS="," read -ra BRANCH_FILTERS \<<< "<< parameters.only_for_branches >>"
+
+        for i in "${BRANCH_FILTERS[@]}"; do
+          if [ "${i}" == "${CIRCLE_BRANCH}" ]; then
+            current_branch_in_filter=true
+          fi
+        done
+
+        if [ "x" == "x<< parameters.only_for_branches>>" ] || [ "$current_branch_in_filter" = true ]; then
+          # If successful
+          if [ "$PUSHOVER_BUILD_STATUS" = "success" ]; then
+            # Skip if fail_only
+            if [ << parameters.fail_only >> = true ]; then
+              echo "The job completed successfully"
+              echo '"fail_only" is set to "true". No Pushover notification sent.'
+            else
+              curl -s \
+                --form-string "token=${<<parameters.api-key>>}" \
+                --form-string "user=${<<parameters.user-key>>}" \
+                --form-string "title=<<parameters.title>>" \
+                --form-string "message=<<parameters.message>>" \
+                --form-string "priority=<<parameters.priority>>" \
+                https://api.pushover.net/1/messages.json
+            fi
+          # If Failed
+          else
+            curl -s \
+              --form-string "token=${<<parameters.api-key>>}" \
+              --form-string "user=${<<parameters.user-key>>}" \
+              --form-string "title=<<parameters.title>>" \
+              --form-string "message=<<parameters.message>>" \
+              --form-string "priority=<<parameters.priority>>" \
+              https://api.pushover.net/1/messages.json
+          fi
+        fi

--- a/src/commands/notify.yml
+++ b/src/commands/notify.yml
@@ -27,75 +27,15 @@ parameters:
     description: "Notification priority (low-to-high: -2 to 1)"
     type: integer
     default: 0
-  fail_only:
-    description: If `true`, notifications successful jobs will not be sent
-    type: boolean
-    default: false
-  only_for_branches:
-    description: If set, a comma-separated list of branches for which to send notifications. No spaces.
-    type: string
-    default: ""
 
 steps:
   - run:
-      name: Pushover - Setting Failure Condition
-      command: |
-        echo 'export PUSHOVER_BUILD_STATUS="fail"' >> $BASH_ENV
-      when: on_fail
-
-  - run:
-      name: Pushover - Setting Success Condition
-      command: |
-        echo 'export PUSHOVER_BUILD_STATUS="success"' >> $BASH_ENV
-      when: on_success
-
-  - run:
-      name: Provide error if non-bash shell
-      command: |
-        if [ ! -x /bin/bash ]; then
-          echo Bash not installed.
-          exit 1
-        fi
-
-  - run:
       name: Notify via Pushover
-      shell: /bin/bash
-      when: always
       command: |
-        current_branch_in_filter=false
-
-        IFS="," read -ra BRANCH_FILTERS \<<< "<< parameters.only_for_branches >>"
-
-        for i in "${BRANCH_FILTERS[@]}"; do
-          if [ "${i}" == "${CIRCLE_BRANCH}" ]; then
-            current_branch_in_filter=true
-          fi
-        done
-
-        if [ "x" == "x<< parameters.only_for_branches>>" ] || [ "$current_branch_in_filter" = true ]; then
-          # If successful
-          if [ "$PUSHOVER_BUILD_STATUS" = "success" ]; then
-            # Skip if fail_only
-            if [ << parameters.fail_only >> = true ]; then
-              echo "The job completed successfully"
-              echo '"fail_only" is set to "true". No Pushover notification sent.'
-            else
-              curl -s \
-                --form-string "token=${<<parameters.api-key>>}" \
-                --form-string "user=${<<parameters.user-key>>}" \
-                --form-string "title=<<parameters.title>>" \
-                --form-string "message=<<parameters.message>>" \
-                --form-string "priority=<<parameters.priority>>" \
-                https://api.pushover.net/1/messages.json
-            fi
-          # If Failed
-          else
-            curl -s \
-              --form-string "token=${<<parameters.api-key>>}" \
-              --form-string "user=${<<parameters.user-key>>}" \
-              --form-string "title=<<parameters.title>>" \
-              --form-string "message=<<parameters.message>>" \
-              --form-string "priority=<<parameters.priority>>" \
-              https://api.pushover.net/1/messages.json
-          fi
-        fi
+        curl -s \
+          --form-string "token=${<<parameters.api-key>>}" \
+          --form-string "user=${<<parameters.user-key>>}" \
+          --form-string "title=<<parameters.title>>" \
+          --form-string "message=<<parameters.message>>" \
+          --form-string "priority=<<parameters.priority>>" \
+          https://api.pushover.net/1/messages.json

--- a/src/examples/notify-on-failure.yml
+++ b/src/examples/notify-on-failure.yml
@@ -1,0 +1,25 @@
+description: |
+  Send a notification with title and message on failure
+
+usage:
+  version: 2.1
+
+  orbs:
+    pushover: pbrisbin/pushover@x.y
+
+  jobs:
+    your-awsome-job:
+      docker:
+        - image: cimg/node:current
+      steps:
+        - checkout
+        - run:
+            command: any tests
+        - pushover/notify-on-failure:
+            name: notify on failure
+            only_for_branches: master develop
+
+  workflows:
+    ordinary:
+      jobs:
+        - your-awsome-job


### PR DESCRIPTION
Hi @pbrisbin,

I want to notify me when the CI of the master branch fails. So, I added `notify-on-failure` command.

I really wanted to add `notify-on-failure` **job**, but I gave up because CircleCI is impossible to run a final job in workflow unconditionally.
See also https://discuss.circleci.com/t/how-to-always-run-a-sequential-final-job-e-g-slack-notification/35362

I referred to Slack orb:

* https://github.com/CircleCI-Public/slack-orb/blob/v3.4.2/src/commands/notify-on-failure.yml
    * https://github.com/CircleCI-Public/slack-orb/blob/v3.4.2/src/commands/status.yml

Thanks for the useful orb!
